### PR TITLE
Introduce property "urlLaunchParameters"

### DIFF
--- a/example/src/app.tsx
+++ b/example/src/app.tsx
@@ -1,11 +1,14 @@
 import {ui, TextView} from 'tabris';
 
 ui.contentView.append(
-  <textView markupEnabled
-    centerX={0} centerY={0}
-    font='24px'
-    text='Awaiting launch by URL...'>
-  </textView>
+  <widgetCollection>
+    <textView markupEnabled
+      centerX={0} centerY={0}
+      font='24px'
+      text='Awaiting launch by URL...' />
+    <button bottom={16} left={16} right={16} text='Log urlLaunchParameters'
+      onSelect={() => console.log(JSON.stringify(eslaunchmonitor.urlLaunchParameters))} />
+  </widgetCollection>
 );
 
 eslaunchmonitor.on({urlLaunch: ({queryParameters}) => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,9 +3,11 @@ import { EventObject } from 'tabris';
 interface LaunchEvents {
   urlLaunch?(event: MessageEvent): void;
 }
-interface MessageEvent extends EventObject<LaunchMonitor> {
+interface UrlLaunchParameters {
   queryParameters: {[key: string]: any};
 }
+interface MessageEvent extends EventObject<LaunchMonitor> {}
+interface MessageEvent extends UrlLaunchParameters {}
 
 interface LaunchMonitor {
   on(type: string, listener: (event: any) => void, context?: object): this;
@@ -14,6 +16,7 @@ interface LaunchMonitor {
   off(listeners: LaunchEvents): this;
   once(type: string, listener: (event: any) => void, context?: object): this;
   once(listeners: LaunchEvents): this;
+  urlLaunchParameters: UrlLaunchParameters
 }
 declare global {
   var eslaunchmonitor: LaunchMonitor;

--- a/www/LaunchMonitor.js
+++ b/www/LaunchMonitor.js
@@ -1,4 +1,7 @@
-var EVENT_TYPES = ['urlLaunch'];
+var URL_LAUNCH_EVENT = 'urlLaunch';
+var EVENT_TYPES = [URL_LAUNCH_EVENT];
+
+var urlLaunchParameters = null;
 
 var LaunchMonitor = tabris.NativeObject.extend('com.eclipsesource.tabris.LaunchMonitor');
 
@@ -9,5 +12,24 @@ LaunchMonitor.prototype._listen = function(name, listening) {
     tabris.Widget.prototype._listen.call(this, name, listening);
   }
 };
+
+LaunchMonitor.prototype._trigger = function(name, event) {
+  if (name === URL_LAUNCH_EVENT) {
+    urlLaunchParameters = {queryParameters: event.queryParameters};
+  }
+  tabris.Widget.prototype._trigger.call(this, name, event);
+};
+
+tabris.NativeObject.defineProperties(LaunchMonitor.prototype, {
+  urlLaunchParameters: {
+    type: 'any',
+    set: function(name) {
+      console.warn(`Can not set read-only property "${name}"`)
+    },
+    get: function() {
+      return urlLaunchParameters;
+    }
+  }
+})
 
 module.exports = new LaunchMonitor();


### PR DESCRIPTION
Useful if listening to the "urlLaunch" event early on is not possible.

Opt for a JS-only implementation of the property to prevent unneeded
native implementation overhead.

Change-Id: I2a4ffcc9ce3e970ebf7fef3936ef2e72fdff9276