### PR TITLE
Fix kotlin compile error

### DIFF
--- a/project/android/launchmonitor/build.gradle
+++ b/project/android/launchmonitor/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 dependencies {
-    implementation 'com.eclipsesource.tabris:tabris-android:2.6.2'
+    implementation 'com.eclipsesource.tabris:tabris-android:2.10.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }
 

--- a/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
+++ b/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
@@ -24,17 +24,18 @@ class LaunchMonitor(activity: Activity, tabrisContext: TabrisContext) {
     }
   }
 
-  private fun parseQuery(url:String?):Map<String, String>? {
+  private fun parseQuery(url: String?): Map<String, String>? {
     if (url == null) return HashMap<String, String>()
     val launchUri = Uri.parse(url)
     if (launchUri.query == null) return HashMap<String, String>()
     val result = HashMap<String, String>()
-    val pairs = launchUri.query.split("&").dropLastWhile { it.isEmpty() }.toTypedArray()
-    pairs.forEach {
-      val idx = it.indexOf("=")
-      val key = URLDecoder.decode(it.substring(0, idx), "UTF-8")
-      val value = URLDecoder.decode(it.substring(idx + 1), "UTF-8")
-      result[key] = value
+    launchUri?.query?.split("&")?.dropLastWhile { it.isEmpty() }?.toTypedArray()?.let { pairs ->
+      pairs.forEach {
+        val idx = it.indexOf("=")
+        val key = URLDecoder.decode(it.substring(0, idx), "UTF-8")
+        val value = URLDecoder.decode(it.substring(idx + 1), "UTF-8")
+        result[key] = value
+      }
     }
     return result
   }


### PR DESCRIPTION
The change fixes the error 'Smart cast to 'String' is impossible, because 'launchUri.query' is a property that has open or custom getter'. Additionally, it upgrades the version of 'tabris-android' implementation.