### PR TITLE
Fix compile errors

### DIFF
--- a/project/android/build.gradle
+++ b/project/android/build.gradle
@@ -1,13 +1,13 @@
 buildscript {
     ext {
-        kotlinVersion= '1.3.71'
+        kotlinVersion= '1.4.10'
     }
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/project/android/gradle/wrapper/gradle-wrapper.properties
+++ b/project/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 26 15:06:39 CEST 2018
+#Thu Oct 29 13:31:13 AZT 2020
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/project/android/launchmonitor/build.gradle
+++ b/project/android/launchmonitor/build.gradle
@@ -2,17 +2,18 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 dependencies {
-    implementation 'com.eclipsesource.tabris.android:tabris:3.4.0'
+    implementation 'com.eclipsesource.tabris.android:tabris:3.7.0'
+    implementation "androidx.fragment:fragment-ktx:1.3.0-beta01"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
 }
 
 android {
 
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     lintOptions {

--- a/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
+++ b/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
@@ -17,7 +17,7 @@ class LaunchMonitor(scope: ActivityScope) {
         notifyUrlLaunch(scope, scope.activity.intent)
       }
     }
-      scope.events.addActivityStateListener(object : Events.ActivityStateListener {
+    scope.events.addActivityStateListener(object : Events.ActivityStateListener {
       override fun activityStateChanged(state: ActivityState, intent: Intent?) {
         when (state) {
           ActivityState.NEW_INTENT -> notifyUrlLaunch(scope, intent)
@@ -36,17 +36,18 @@ class LaunchMonitor(scope: ActivityScope) {
     scope.objectRegistry.findRemoteObject(this)?.notify(EVENT_URL_LAUNCH, urlLaunchParameters)
   }
 
-  private fun parseQuery(url:String?):Map<String, String>? {
+  private fun parseQuery(url: String?): Map<String, String>? {
     if (url == null) return HashMap<String, String>()
     val launchUri = Uri.parse(url)
     if (launchUri.query == null) return HashMap<String, String>()
     val result = HashMap<String, String>()
-    val pairs = launchUri.query.split("&").dropLastWhile { it.isEmpty() }.toTypedArray()
-    pairs.forEach {
-      val idx = it.indexOf("=")
-      val key = URLDecoder.decode(it.substring(0, idx), "UTF-8")
-      val value = URLDecoder.decode(it.substring(idx + 1), "UTF-8")
-      result[key] = value
+    launchUri?.query?.split("&")?.dropLastWhile { it.isEmpty() }?.toTypedArray()?.let { pairs ->
+      pairs.forEach {
+        val idx = it.indexOf("=")
+        val key = URLDecoder.decode(it.substring(0, idx), "UTF-8")
+        val value = URLDecoder.decode(it.substring(idx + 1), "UTF-8")
+        result[key] = value
+      }
     }
     return result
   }


### PR DESCRIPTION
The change:
* Fixes the error "Smart cast to 'String' is impossible, because 'launchUri.query' is a property that has open or custom getter" which is thrown during an app build.
* Adds 'fragment-ktx' implementation in order to fix compile error.
* Upgrades kotlin, Gradle, and 'tabris-android' versions.