### PR TITLE
🐛 Update outdated peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React on Tabris.js app launch and read launch parameters.",
   "types": "./types/index.d.ts",
   "peerDependencies": {
-    "tabris": "~3.4.0"
+    "tabris": "^3.9.0-dev"
   },
   "cordova": {
     "id": "tabris-plugin-launchmonitor",


### PR DESCRIPTION
Starting with `npm@7`, peer dependencies fail to install when they do not match the range declared for the peer dependency.

`tabris-plugin-launchmonitor` declared only being compatible with the severely outdated `tabris@3.0.x`. Use the range `^3.9.0-dev` instead, which is compatible with latest stable and nightly Tabris.js 3.9 versions. Analogous to [1].

[1]: eclipsesource/tabris-decorators@520562e