### PR TITLE
Ensure `urlLaunch` event is triggered correctly

### DIFF
--- a/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
+++ b/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
@@ -3,7 +3,6 @@ package com.eclipsesource.tabris.launchmonitor
 import android.content.Intent
 import com.eclipsesource.tabris.android.*
 import android.net.Uri
-import android.os.Handler;
 import java.net.URLDecoder
 import java.util.*
 
@@ -12,9 +11,11 @@ private const val EVENT_URL_LAUNCH = "urlLaunch"
 class LaunchMonitor(scope: ActivityScope) {
 
   init {
-    Handler().post {
+    scope.post {
       if (scope.activity.intent.dataString != null) {
-        notifyUrlLaunch(scope, scope.activity.intent)
+        scope.handler.postDelayed({
+          notifyUrlLaunch(scope, scope.activity.intent)
+        }, 0)
       }
     }
     scope.events.addActivityStateListener(object : Events.ActivityStateListener {


### PR DESCRIPTION
Previously, the `urlLaunch` event handler was not being called when the app was launched through a URL, and the app hadn't been opened at all. The `urlLaunch` event was fired before the corresponding JavaScript handler on the app's side was initiated.

Run the JavaScript handler invoke within a new Runnable and delay the execution start by 0 milliseconds.

Replace the standalone instance of the `Handler()` class with a scope handler.