### PR TITLE
Fix 'when' expression error in LaunchMonitor

### DIFF
--- a/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
+++ b/src/android/com/eclipsesource/tabris/launchmonitor/LaunchMonitor.kt
@@ -22,6 +22,9 @@ class LaunchMonitor(scope: ActivityScope) {
       override fun activityStateChanged(state: ActivityState, intent: Intent?) {
         when (state) {
           ActivityState.NEW_INTENT -> notifyUrlLaunch(scope, intent)
+          else -> {
+            // No action needed for other states
+          }
         }
       }
     })


### PR DESCRIPTION
The 'when' expression in `activityStateChanged` in LaunchMonitor was not exhaustive, causing compile errors and failing the app build.

Added an `else` branch to handle all other `ActivityState` values, ensuring compliance with Kotlin's exhaustiveness requirements and preventing compile errors.